### PR TITLE
Soft reboot when theme is uninstalled fix

### DIFF
--- a/patches/frameworks_base/0004-Fixed-uncaught-IllegalStateException-and-soft-reboot.patch
+++ b/patches/frameworks_base/0004-Fixed-uncaught-IllegalStateException-and-soft-reboot.patch
@@ -1,0 +1,34 @@
+From 382ed5488b4dc67ea3a6d289e70d5383343dd5b4 Mon Sep 17 00:00:00 2001
+From: Kenan Garibov <kengnatural@gmail.com>
+Date: Thu, 4 Feb 2016 21:35:55 +0200
+Subject: [PATCH] Fixed uncaught IllegalStateException and soft reboot when
+ theme was uninstalled.
+
+Change-Id: I67af2baae094a572910448d7d684c26ad790167f
+---
+ core/java/android/content/pm/ThemeUtils.java | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/core/java/android/content/pm/ThemeUtils.java b/core/java/android/content/pm/ThemeUtils.java
+index 3cf15d3..982d9b0 100644
+--- a/core/java/android/content/pm/ThemeUtils.java
++++ b/core/java/android/content/pm/ThemeUtils.java
+@@ -622,8 +622,13 @@ public class ThemeUtils {
+             List<String> allComponents = getAllComponents();
+             for(String component : allComponents) {
+                 int index = c.getColumnIndex(component);
+-                if (c.getInt(index) == 1) {
+-                    supportedComponents.add(component);
++                if (index != -1) {
++                    if (c.getInt(index) == 1) {
++                        supportedComponents.add(component);
++                    }
++                }
++                else {
++                    Log.w(TAG, "Column " + component + " does not exists");
+                 }
+             }
+         }
+--
+2.7.0
+


### PR DESCRIPTION
Added a patch to fix uncaught IllegalStateException and soft reboot when a theme is uninstalled. It should be manually applied.
