### PR TITLE
Broken xposed and /hidden partition issue

### DIFF
--- a/patches/frameworks_base/0005-AndroidRuntime-legacy-startvm-function-returned-back.patch
+++ b/patches/frameworks_base/0005-AndroidRuntime-legacy-startvm-function-returned-back.patch
@@ -1,0 +1,80 @@
+From b2731a4d91ddecf3cfd03ab17403592cda8e7948 Mon Sep 17 00:00:00 2001
+From: Kenan Garibov <kengnatural@gmail.com>
+Date: Sat, 6 Feb 2016 17:19:51 +0200
+Subject: [PATCH] AndroidRuntime legacy startvm() function returned back to fix
+ broken xposed framework. Fix proposed by Stefan Berger
+ <s.berger81@gmail.com>.
+
+Change-Id: I5fad896519b2c58086be534a67b69989080712d3
+---
+ core/jni/AndroidRuntime.cpp              | 26 ++++++++++++++++++++++++++
+ include/android_runtime/AndroidRuntime.h |  2 ++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/core/jni/AndroidRuntime.cpp b/core/jni/AndroidRuntime.cpp
+index b8acead..dab7b3b 100644
+--- a/core/jni/AndroidRuntime.cpp
++++ b/core/jni/AndroidRuntime.cpp
+@@ -433,6 +433,19 @@ void AndroidRuntime::parseExtraOpts(char* extraOptsBuf)
+  *
+  * Returns 0 on success.
+  */
++int AndroidRuntime::startVm(JavaVM** pJavaVM, JNIEnv** pEnv)
++{
++    return startVm(pJavaVM, pEnv, false);
++}
++
++/*
++ * Start the Dalvik Virtual Machine.
++ *
++ * Various arguments, most determined by system properties, are passed in.
++ * The "mOptions" vector is updated.
++ *
++ * Returns 0 on success.
++ */
+ int AndroidRuntime::startVm(JavaVM** pJavaVM, JNIEnv** pEnv, bool zygote)
+ {
+     int result = -1;
+@@ -807,6 +820,19 @@ char* AndroidRuntime::toSlashClassName(const char* className)
+  * Passes the main function two arguments, the class name and the specified
+  * options string.
+  */
++void AndroidRuntime::start(const char* className, const char* options)
++{
++    start(className, options, false);
++}
++
++/*
++ * Start the Android runtime.  This involves starting the virtual machine
++ * and calling the "static void main(String[] args)" method in the class
++ * named by "className".
++ *
++ * Passes the main function two arguments, the class name and the specified
++ * options string.
++ */
+ void AndroidRuntime::start(const char* className, const char* options, bool zygote)
+ {
+     ALOGD("\n>>>>>> AndroidRuntime START %s <<<<<<\n",
+diff --git a/include/android_runtime/AndroidRuntime.h b/include/android_runtime/AndroidRuntime.h
+index e8e869d..ba2f569 100644
+--- a/include/android_runtime/AndroidRuntime.h
++++ b/include/android_runtime/AndroidRuntime.h
+@@ -64,6 +64,7 @@ public:
+ 
+     int addVmArguments(int argc, const char* const argv[]);
+ 
++    void start(const char *classname, const char* options);
+     void start(const char *classname, const char* options, bool zygote);
+ 
+     void exit(int code);
+@@ -117,6 +118,7 @@ private:
+     static int startReg(JNIEnv* env);
+     void parseExtraOpts(char* extraOptsBuf);
+     int startVm(JavaVM** pJavaVM, JNIEnv** pEnv, bool zygote);
++    int startVm(JavaVM** pJavaVM, JNIEnv** pEnv);
+ 
+     Vector<JavaVMOption> mOptions;
+     bool mExitWithoutCleanup;
+-- 
+2.7.0
+

--- a/ramdisk/fstab.qcom
+++ b/ramdisk/fstab.qcom
@@ -15,7 +15,7 @@
 /dev/block/mmcblk0p12                      /recovery   emmc   defaults                                       defaults
 /dev/block/mmcblk0p19                      /efs        ext4   nosuid,nodev,barrier=1                         wait,check
 /dev/block/mmcblk0p11                      /persist    ext4   nosuid,nodev,barrier=1                         wait
-/dev/block/mmcblk0p22                      /hidden     ext4   noatime,nosuid,nodev,barrier=1,noauto_da_alloc,journal_async_commit                         wait
+#/dev/block/mmcblk0p22                      /hidden     ext4   noatime,nosuid,nodev,barrier=1,noauto_da_alloc,journal_async_commit                         wait
 
 /devices/platform/msm_sdcc.1/mmc_host/mmc1 auto        auto   defaults                                       voldmanaged=sdcard0:auto
 /devices/platform/msm_hsusb_host.0/usb1    auto        auto   defaults                                       voldmanaged=usbdisk0:auto


### PR DESCRIPTION
- Local patch was added to return back obsolete start and startvm() functions.
- /hidden entry removed from fstab.qcom
