### PR TITLE
Default governor and flooding ALOGD

### DIFF
--- a/libaudio/AudioHardware.h
+++ b/libaudio/AudioHardware.h
@@ -273,10 +273,10 @@ private:
             char af_quality[PROPERTY_VALUE_MAX];
             property_get("af.resampler.quality",af_quality,"0");
             if(strcmp("255",af_quality) == 0) {
-                ALOGD("SampleRate 48k");
+                //ALOGD("SampleRate 48k");
                 return 48000;
             } else {
-                ALOGD("SampleRate 44.1k");
+                //ALOGD("SampleRate 44.1k");
                 return 44100;
             }
         }
@@ -284,10 +284,10 @@ private:
             char af_quality[PROPERTY_VALUE_MAX];
             property_get("af.resampler.quality",af_quality,"0");
             if(strcmp("255",af_quality) == 0) {
-                ALOGD("Bufsize 5248");
+                //ALOGD("Bufsize 5248");
                 return 5248;
             } else {
-                ALOGD("Bufsize 4800");
+                //ALOGD("Bufsize 4800");
                 return 4800;
             }
         }

--- a/ramdisk/init.qcom.rc
+++ b/ramdisk/init.qcom.rc
@@ -150,7 +150,8 @@ on boot
     chown radio:radio /dev/oncrpc/30000012:00040000
 
     # Power management
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor performance
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ondemand
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 245760
     write /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate 25000
     write /sys/devices/system/cpu/cpufreq/ondemand/up_threshold 90
     write /sys/devices/system/cpu/cpufreq/ondemand/io_is_busy 1


### PR DESCRIPTION
- During analysys of logcat files I noticed that sound device emits a lot of debug messages and floods the log output. I commented these logs.
- Default governor changed to onDemand and min frequency was set to 245MHz. When user first install the system Performance menu is not accessable and default values are not good for battery.
