### PR TITLE
Fixed writing sequence to the notification backlight files.

### DIFF
--- a/liblights/lights.c
+++ b/liblights/lights.c
@@ -111,8 +111,8 @@ static int set_light_notifications(struct light_device_t* dev, struct light_stat
 
      if(on)
      {
-         write_int(NOTIFICATION_FILE, 1);
          write_int(NOTIFICATION_ENABLE_FILE, 1);
+         write_int(NOTIFICATION_FILE, 1);
      }
      else
      {


### PR DESCRIPTION
Change-Id: I77b4c4fe461c7ad2f455c2d4845165cac073238b
The sequence of writing to these files does matter.
